### PR TITLE
Prevent redacting of empty values

### DIFF
--- a/src/RedactSensitiveProcessor.php
+++ b/src/RedactSensitiveProcessor.php
@@ -55,17 +55,15 @@ class RedactSensitiveProcessor implements ProcessorInterface
             return $value;
         }
 
-        $hidden_length = $valueLength - abs($length);
-        $hidden = str_repeat($this->replacement, $hidden_length);
+        $hiddenLength = $valueLength - abs($length);
+        $hidden = str_repeat($this->replacement, $hiddenLength);
         $placeholder = sprintf($this->template, $hidden);
 
-        $result = substr_replace($value, $placeholder, max(0, $length), $hidden_length);
+        $result = substr_replace($value, $placeholder, max(0, $length), $hiddenLength);
 
-        $result = $length > 0
+        return $length > 0
             ? substr($result, 0, $this->lengthLimit)
             : substr($result, -$this->lengthLimit);
-
-        return $result;
     }
 
     /**

--- a/src/RedactSensitiveProcessor.php
+++ b/src/RedactSensitiveProcessor.php
@@ -49,7 +49,13 @@ class RedactSensitiveProcessor implements ProcessorInterface
 
     private function redact(string $value, int $length): string
     {
-        $hidden_length = strlen($value) - abs($length);
+        $valueLength = strlen($value);
+
+        if ($valueLength === 0) {
+            return $value;
+        }
+
+        $hidden_length = $valueLength - abs($length);
         $hidden = str_repeat($this->replacement, $hidden_length);
         $placeholder = sprintf($this->template, $hidden);
 

--- a/tests/RedactSensitiveTest.php
+++ b/tests/RedactSensitiveTest.php
@@ -124,6 +124,14 @@ it('redacts inside nested objects', function (): void {
     expect($nested->nested['value'])->toBe('***qux');
 });
 
+it('preserves empty values', function (): void {
+    $sensitive_keys = ['test' => 3, 'optionalKey' => 10];
+    $processor = new RedactSensitiveProcessor($sensitive_keys);
+
+    $record = $this->getRecord(context: ['test' => 'foobar', 'optionalKey' => '']);
+    expect($processor($record)->context)->toBe(['test' => 'foo***', 'optionalKey' => '']);
+});
+
 it('throws when finds an un-traversable value', function (): void {
     $sensitive_keys = ['test' => 3];
     $processor = new RedactSensitiveProcessor($sensitive_keys);


### PR DESCRIPTION
This pull request should prevent throwing an error when the value being redacted is actually empty. Currently it would throw an error at `src/RedactSensitiveProcessor.php:53`
```
 str_repeat(): Argument #2 ($times) must be greater than or equal to 0
```