### PR TITLE
Exception when value is null

### DIFF
--- a/src/RedactSensitiveProcessor.php
+++ b/src/RedactSensitiveProcessor.php
@@ -95,7 +95,7 @@ class RedactSensitiveProcessor implements ProcessorInterface
             } else {
                 if (array_key_exists($key, $keys)) {
                     $arr[$key] = $this->traverse($key, $value, $keys[$key]);
-                } else {
+                } elseif (null !== $value) {
                     $arr[$key] = $this->traverse($key, $value, $keys);
                 }
             }
@@ -115,7 +115,7 @@ class RedactSensitiveProcessor implements ProcessorInterface
             } else {
                 if (array_key_exists($key, $keys)) {
                     $obj->{$key} = $this->traverse($key, $value, $keys[$key]);
-                } else {
+                } elseif (null !== $value) {
                     $obj->{$key} = $this->traverse($key, $value, $keys);
                 }
             }

--- a/tests/RedactSensitiveTest.php
+++ b/tests/RedactSensitiveTest.php
@@ -139,3 +139,11 @@ it('throws when finds an un-traversable value', function (): void {
     $record = $this->getRecord(context: ['test' => fopen(__FILE__, 'rb')]);
     $processor($record);
 })->throws(\UnexpectedValueException::class, 'Don\'t know how to traverse value at key test');
+
+it('ignore when null value', function (): void {
+    $sensitive_keys = ['test' => 3];
+    $processor = new RedactSensitiveProcessor($sensitive_keys);
+
+    $record = $this->getRecord(context: ['test' => 'foobar', 'optionalKey' => null]);
+    expect($processor($record)->context)->toBe(['test' => 'foo***', 'optionalKey' => null]);
+});


### PR DESCRIPTION
Hey. I found a problem when some key has a `null` value. An exception is thrown.

```
In RedactSensitiveProcessor.php line 84:
                                                         
  Don't know how to traverse value at key correlationId 
```

I add `null` value check instead just `else` and `traverse` all kind of values.