### PR TITLE
Type missmatch when key is int

### DIFF
--- a/src/RedactSensitiveProcessor.php
+++ b/src/RedactSensitiveProcessor.php
@@ -47,7 +47,7 @@ class RedactSensitiveProcessor implements ProcessorInterface
         return $record->with(context: $redactedContext);
     }
 
-    private function redact(string $value, int $length): string
+    private function redact(int|string $value, int $length): string
     {
         $valueLength = strlen($value);
 

--- a/src/RedactSensitiveProcessor.php
+++ b/src/RedactSensitiveProcessor.php
@@ -47,7 +47,7 @@ class RedactSensitiveProcessor implements ProcessorInterface
         return $record->with(context: $redactedContext);
     }
 
-    private function redact(int|string $value, int $length): string
+    private function redact(string $value, int $length): string
     {
         $valueLength = strlen($value);
 
@@ -71,7 +71,7 @@ class RedactSensitiveProcessor implements ProcessorInterface
      * @param array|int $keys
      * @return array|object
      */
-    private function traverse(string $key, $value, $keys)
+    private function traverse(int|string $key, $value, $keys)
     {
         if (is_array($value)) {
             return $this->traverseArr($value, $keys);

--- a/tests/RedactSensitiveTest.php
+++ b/tests/RedactSensitiveTest.php
@@ -147,3 +147,11 @@ it('ignore when null value', function (): void {
     $record = $this->getRecord(context: ['test' => 'foobar', 'optionalKey' => null]);
     expect($processor($record)->context)->toBe(['test' => 'foo***', 'optionalKey' => null]);
 });
+
+it('redacts nested values when key is integer', function (): void {
+    $sensitive_keys = ['test' => 3];
+    $processor = new RedactSensitiveProcessor($sensitive_keys);
+
+    $record = $this->getRecord(context: [0 => ['good' => 'value'], 1 => ['test' => 'foobar']]);
+    expect($processor($record)->context)->toBe([0 => ['good' => 'value'], 1 => ['test' => 'foo***']]);
+});


### PR DESCRIPTION
Hey! Another bug and another fix ;)

When key in context is integer there is an exception due to hardcoded `string` type in `traverse` method. I just changed type to union `int|string` and now all works fine. I think keys in context shouldn't be anything else than `int` or `string`.

Feel free to negate my solution if you have a different vision.