### PR TITLE
Fix for Nested Sensitive Keys

### DIFF
--- a/src/RedactSensitiveProcessor.php
+++ b/src/RedactSensitiveProcessor.php
@@ -81,7 +81,7 @@ class RedactSensitiveProcessor implements ProcessorInterface
             return $this->traverseObj($value, $keys);
         }
 
-        throw new UnexpectedValueException("Don't know how to traverse value at key $key");
+        throw new UnexpectedValueException("Don't know how to traverse value of type " . gettype($value) ." at key $key");
     }
 
     private function traverseArr(array $arr, array $keys): array
@@ -93,7 +93,7 @@ class RedactSensitiveProcessor implements ProcessorInterface
                 }
                 continue;
             } else {
-                if (array_key_exists($key, $keys)) {
+                if (array_key_exists($key, $keys) && is_array($keys[$key])) {
                     $arr[$key] = $this->traverse($key, $value, $keys[$key]);
                 } elseif (null !== $value) {
                     $arr[$key] = $this->traverse($key, $value, $keys);
@@ -113,7 +113,7 @@ class RedactSensitiveProcessor implements ProcessorInterface
                 }
                 continue;
             } else {
-                if (array_key_exists($key, $keys)) {
+                if (array_key_exists($key, $keys) && is_array($keys[$key])) {
                     $obj->{$key} = $this->traverse($key, $value, $keys[$key]);
                 } elseif (null !== $value) {
                     $obj->{$key} = $this->traverse($key, $value, $keys);

--- a/tests/RedactSensitiveTest.php
+++ b/tests/RedactSensitiveTest.php
@@ -140,6 +140,16 @@ it('throws when finds an un-traversable value', function (): void {
     $processor($record);
 })->throws(\UnexpectedValueException::class, 'Don\'t know how to traverse value of type resource at key test');
 
+it('should not throw when non-scalar value, but keys are not nested', function (): void {
+    $sensitive_keys = ['test' => -4];
+    $obj = new \stdClass();
+    $processor = new RedactSensitiveProcessor($sensitive_keys);
+
+    $record = $this->getRecord(context: ['test' => $obj]);
+    $processor($record);
+    expect($processor($record)->context)->toBe(['test' => $obj]);
+});
+
 it('ignore when null value', function (): void {
     $sensitive_keys = ['test' => 3];
     $processor = new RedactSensitiveProcessor($sensitive_keys);

--- a/tests/RedactSensitiveTest.php
+++ b/tests/RedactSensitiveTest.php
@@ -138,7 +138,7 @@ it('throws when finds an un-traversable value', function (): void {
 
     $record = $this->getRecord(context: ['test' => fopen(__FILE__, 'rb')]);
     $processor($record);
-})->throws(\UnexpectedValueException::class, 'Don\'t know how to traverse value at key test');
+})->throws(\UnexpectedValueException::class, 'Don\'t know how to traverse value of type resource at key test');
 
 it('ignore when null value', function (): void {
     $sensitive_keys = ['test' => 3];


### PR DESCRIPTION
## Description

When running this package on my local server, I encountered an error where if a value is non-scalar, and you were not nesting keys, you would run into a type error.

Example: I created a test in RedactSensitiveTest.php

```
it('should not throw when non-scalar value, but keys are not nested', function (): void {
    $sensitive_keys = ['test' => -4];
    $obj = new \stdClass();
    $processor = new RedactSensitiveProcessor($sensitive_keys);

    $record = $this->getRecord(context: ['test' => $obj]);
    $processor($record);
    expect($processor($record)->context)->toBe(['test' => $obj]);
})
```

When running the tests, I encountered a type error

```
 RedactSensitive\RedactSensitiveProcessor::traverseObj(): Argument #2 ($keys) must be of type array, int given, called in src/RedactSensitiveProcessor.php on line 81

  at src/RedactSensitiveProcessor.php:107
    103▕ 
    104▕         return $arr;
    105▕     }
    106▕ 
  ➜ 107▕     private function traverseObj(object $obj, array $keys): object
    108▕     {
    109▕         foreach (get_object_vars($obj) as $key => $value) {
    110▕             if (is_scalar($value)) {
    111▕                 if (array_key_exists($key, $keys)) {

  1   src/RedactSensitiveProcessor.php:107
  2   src/RedactSensitiveProcessor.php:81


  Tests:    1 failed, 18 passed (23 assertions)
  Duration: 0.13s
```

## Expected Behavior
This should traverse objects/arrays that are mapped to a sensitive key, regardless of if the key inside of the `sensitive_keys` array is nested.

## Fix
Check if the sensitive key is mapped to an array. If it is, then use the nested keys. Otherwise, traverse using the given keys.
