### PR TITLE
Fix For Redacting Readonly Properties

### DIFF
--- a/src/RedactSensitiveProcessor.php
+++ b/src/RedactSensitiveProcessor.php
@@ -81,7 +81,7 @@ class RedactSensitiveProcessor implements ProcessorInterface
             return $this->traverseObj($value, $keys);
         }
 
-        throw new UnexpectedValueException("Don't know how to traverse value at key $key");
+        throw new UnexpectedValueException("Don't know how to traverse value of type " . gettype($value) ." at key $key");
     }
 
     private function traverseArr(array $arr, array $keys): array
@@ -93,7 +93,7 @@ class RedactSensitiveProcessor implements ProcessorInterface
                 }
                 continue;
             } else {
-                if (array_key_exists($key, $keys)) {
+                if (array_key_exists($key, $keys) && is_array($keys[$key])) {
                     $arr[$key] = $this->traverse($key, $value, $keys[$key]);
                 } elseif (null !== $value) {
                     $arr[$key] = $this->traverse($key, $value, $keys);
@@ -113,7 +113,7 @@ class RedactSensitiveProcessor implements ProcessorInterface
                 }
                 continue;
             } else {
-                if (array_key_exists($key, $keys)) {
+                if (array_key_exists($key, $keys) && is_array($keys[$key])) {
                     $obj->{$key} = $this->traverse($key, $value, $keys[$key]);
                 } elseif (null !== $value) {
                     $obj->{$key} = $this->traverse($key, $value, $keys);

--- a/src/RedactSensitiveProcessor.php
+++ b/src/RedactSensitiveProcessor.php
@@ -106,9 +106,8 @@ class RedactSensitiveProcessor implements ProcessorInterface
 
     private function traverseObj(object $obj, array $keys): object
     {
-        $hasReadOnlyProperties = $this->containsReadOnlyProperties($obj);
         $vars = get_object_vars($obj);
-        if ($hasReadOnlyProperties) {
+        if ($this->containsReadOnlyProperties($obj)) {
             // create a new object so that redacted copies of readonly variables
             // can be stored on it
             $obj = new \stdClass();

--- a/src/RedactSensitiveProcessor.php
+++ b/src/RedactSensitiveProcessor.php
@@ -106,7 +106,14 @@ class RedactSensitiveProcessor implements ProcessorInterface
 
     private function traverseObj(object $obj, array $keys): object
     {
-        foreach (get_object_vars($obj) as $key => $value) {
+        $hasReadOnlyProperties = $this->containsReadOnlyProperties($obj);
+        $vars = get_object_vars($obj);
+        if ($hasReadOnlyProperties) {
+            // create a new object so that redacted copies of readonly variables
+            // can be stored on it
+            $obj = new \stdClass();
+        }
+        foreach ($vars as $key => $value) {
             if (is_scalar($value)) {
                 if (array_key_exists($key, $keys)) {
                     $obj->{$key} = $this->redact((string) $value, $keys[$key]);
@@ -122,5 +129,21 @@ class RedactSensitiveProcessor implements ProcessorInterface
         }
 
         return $obj;
+    }
+
+    /**
+     * Determines if an object has readonly properties.
+     * @param object $object
+     * @return bool
+     */
+    private function containsReadOnlyProperties(object $object): bool
+    {
+        $reflection = new \ReflectionObject($object);
+        foreach ($reflection->getProperties() as $property) {
+            if ($property->isReadOnly()) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/tests/RedactSensitiveTest.php
+++ b/tests/RedactSensitiveTest.php
@@ -166,7 +166,7 @@ it('redacts nested values when key is integer', function (): void {
     expect($processor($record)->context)->toBe([0 => ['good' => 'value'], 1 => ['test' => 'foo***']]);
 });
 
-it('creates copies of readonly properties and redacts them', function (): void {
+it('creates copies of objects with readonly properties and redacts them', function (): void {
     $sensitive_keys = ['test' => 0];
     $processor = new RedactSensitiveProcessor($sensitive_keys);
 

--- a/tests/RedactSensitiveTest.php
+++ b/tests/RedactSensitiveTest.php
@@ -140,6 +140,16 @@ it('throws when finds an un-traversable value', function (): void {
     $processor($record);
 })->throws(\UnexpectedValueException::class, 'Don\'t know how to traverse value of type resource at key test');
 
+it('should not throw when non-scalar value, but keys are not nested', function (): void {
+    $sensitive_keys = ['test' => -4];
+    $obj = new \stdClass();
+    $processor = new RedactSensitiveProcessor($sensitive_keys);
+
+    $record = $this->getRecord(context: ['test' => $obj]);
+    $processor($record);
+    expect($processor($record)->context)->toBe(['test' => $obj]);
+});
+
 it('ignore when null value', function (): void {
     $sensitive_keys = ['test' => 3];
     $processor = new RedactSensitiveProcessor($sensitive_keys);

--- a/tests/RedactSensitiveTest.php
+++ b/tests/RedactSensitiveTest.php
@@ -170,13 +170,13 @@ it('creates copies of objects with readonly properties and redacts them', functi
     $sensitive_keys = ['test' => 0];
     $processor = new RedactSensitiveProcessor($sensitive_keys);
 
-    $readonlyPropertiesObject = new class {
+    $readonly_properties_object = new class {
         public function __construct(
             public readonly string $test = 'foobar',
         ) {}
     };
 
-    $record = $this->getRecord(context: ['foo' => $readonlyPropertiesObject]);
+    $record = $this->getRecord(context: ['foo' => $readonly_properties_object]);
     expect($processor($record)->context['foo']->test)->toBe('******');
 });
 

--- a/tests/RedactSensitiveTest.php
+++ b/tests/RedactSensitiveTest.php
@@ -138,7 +138,7 @@ it('throws when finds an un-traversable value', function (): void {
 
     $record = $this->getRecord(context: ['test' => fopen(__FILE__, 'rb')]);
     $processor($record);
-})->throws(\UnexpectedValueException::class, 'Don\'t know how to traverse value at key test');
+})->throws(\UnexpectedValueException::class, 'Don\'t know how to traverse value of type resource at key test');
 
 it('ignore when null value', function (): void {
     $sensitive_keys = ['test' => 3];


### PR DESCRIPTION
## Description
Related to [this issue](https://github.com/leocavalcante/redact-sensitive/issues/7). This enables redacted values of readonly properties to appear in logs.

Added 2 additional tests to verify that `readonly` properties can be redacted.

## Expected Behavior
Logs should show redacted values of `readonly` properties if they defined in the `$sensitive_keys` array.  

## Fix
`traverseObj` checks if an object has `readonly` properties. If an object has `readonly` properties, it uses an instance of `\stdClass` to record redacted versions of the value instead of trying to modify a `readonly` property.